### PR TITLE
[Feat] [ACNA-1056] - Prompt for select workspace should not throw error when creation is intended.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,7 +121,7 @@ class LibConsoleCLI {
 
   async promptForSelectWorkspace (workspaces, data = { workspaceId: undefined, workspaceName: undefined }, options = { allowCreate: false }) {
     let selectedWorkspace
-    if (!options.allowCreate && (data.workspaceId || data.workspaceName)) {
+    if (data.workspaceId || data.workspaceName) {
       selectedWorkspace = helpers.findWorkspaceOrThrow(data.workspaceId, data.workspaceName, workspaces)
     } else {
       const workspaceChoices = helpers.workspacesToPromptChoices(workspaces)

--- a/lib/index.js
+++ b/lib/index.js
@@ -121,7 +121,7 @@ class LibConsoleCLI {
 
   async promptForSelectWorkspace (workspaces, data = { workspaceId: undefined, workspaceName: undefined }, options = { allowCreate: false }) {
     let selectedWorkspace
-    if (data.workspaceId || data.workspaceName) {
+    if (!options.allowCreate && (data.workspaceId || data.workspaceName)) {
       selectedWorkspace = helpers.findWorkspaceOrThrow(data.workspaceId, data.workspaceName, workspaces)
     } else {
       const workspaceChoices = helpers.workspacesToPromptChoices(workspaces)
@@ -183,15 +183,16 @@ class LibConsoleCLI {
     return project
   }
 
-  async promptForCreateWorkspaceDetails () {
+  async promptForCreateWorkspaceDetails (defaultName, defaultTitle = '') {
     // needs support for predefined data input
     console.error('Enter Workspace details:')
     const name = await this.prompt.promptInput('Name', {
-      validate: validators.validateWorkspaceName
+      validate: validators.validateWorkspaceName,
+      default: defaultName
     })
     const title = await this.prompt.promptInput('Title', {
-      default: '',
-      validate: validators.validateWorkspaceTitle
+      validate: validators.validateWorkspaceTitle,
+      default: defaultTitle
     })
     const workspaceDetails = { name, title }
     logger.debug(`Entered Workspace Details: ${JSON.stringify(workspaceDetails, null, 2)}`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,7 @@ class LibConsoleCLI {
   async promptForSelectWorkspace (workspaces, data = { workspaceId: undefined, workspaceName: undefined }, options = { allowCreate: false }) {
     let selectedWorkspace
     if (data.workspaceId || data.workspaceName) {
-      selectedWorkspace = helpers.findWorkspaceOrThrow(data.workspaceId, data.workspaceName, workspaces)
+      selectedWorkspace = helpers.findWorkspace(data, workspaces)
     } else {
       const workspaceChoices = helpers.workspacesToPromptChoices(workspaces)
       // Note: promptSelectOrCreate gives the user the possibility to escape the
@@ -183,16 +183,15 @@ class LibConsoleCLI {
     return project
   }
 
-  async promptForCreateWorkspaceDetails (defaultName, defaultTitle = '') {
+  async promptForCreateWorkspaceDetails () {
     // needs support for predefined data input
     console.error('Enter Workspace details:')
     const name = await this.prompt.promptInput('Name', {
-      validate: validators.validateWorkspaceName,
-      default: defaultName
+      validate: validators.validateWorkspaceName
     })
     const title = await this.prompt.promptInput('Title', {
-      validate: validators.validateWorkspaceTitle,
-      default: defaultTitle
+      default: '',
+      validate: validators.validateWorkspaceTitle
     })
     const workspaceDetails = { name, title }
     logger.debug(`Entered Workspace Details: ${JSON.stringify(workspaceDetails, null, 2)}`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,7 +99,7 @@ class LibConsoleCLI {
   async promptForSelectProject (projects, data = { projectId: undefined, projectName: undefined }, options = { allowCreate: false }) {
     let selectedProject
     if (data.projectId || data.projectName) {
-      selectedProject = helpers.findProjectOrThrow(data.projectId, data.projectName, projects)
+      selectedProject = helpers.findProjectOrThrow(data, projects, { throwOnNotFound: !options.allowCreate })
     } else {
       const projectChoices = helpers.projectsToPromptChoices(projects)
       // Note: promptSelectOrCreate gives the user the possibility to escape the
@@ -122,7 +122,7 @@ class LibConsoleCLI {
   async promptForSelectWorkspace (workspaces, data = { workspaceId: undefined, workspaceName: undefined }, options = { allowCreate: false }) {
     let selectedWorkspace
     if (data.workspaceId || data.workspaceName) {
-      selectedWorkspace = helpers.findWorkspace(data, workspaces)
+      selectedWorkspace = helpers.findWorkspaceOrThrow(data, workspaces, { throwOnNotFound: !options.allowCreate })
     } else {
       const workspaceChoices = helpers.workspacesToPromptChoices(workspaces)
       // Note: promptSelectOrCreate gives the user the possibility to escape the

--- a/lib/pure-helpers.js
+++ b/lib/pure-helpers.js
@@ -98,7 +98,6 @@ function findWorkspace ({
   if (workspaceByName || workspaceById) {
     return workspaceById || workspaceByName
   }
-  return undefined
 }
 
 /** @private */

--- a/lib/pure-helpers.js
+++ b/lib/pure-helpers.js
@@ -78,6 +78,29 @@ function findWorkspaceOrThrow (workspaceId, workspaceName, workspaces) {
   return workspaceById || workspaceByName
 }
 
+/** @private
+ * @returns {object | undefined} result
+ * */
+
+function findWorkspace ({
+  workspaceId,
+  workspaceName
+}, workspaces) {
+  // either workspaceId or workspaceName is defined
+
+  const workspaceByName = workspaceName && workspaces.find(w => w.name === workspaceName)
+  const workspaceById = workspaceId && workspaces.find(w => w.id === workspaceId)
+
+  if (workspaceByName && workspaceById && workspaceById.id !== workspaceByName.id) {
+    throw new Error(`Workspace name '${workspaceName}' and id '${workspaceId}' do not refer to the same Workspace.`)
+  }
+
+  if (workspaceByName || workspaceById) {
+    return workspaceById || workspaceByName
+  }
+  return undefined
+}
+
 /** @private */
 function projectsToPromptChoices (projects) {
   const projectChoices = projects
@@ -285,5 +308,6 @@ module.exports = {
   enhanceWorkspaceConfiguration,
   workspaceNamesToPromptString,
   mergeExtensionPoints,
-  removeExtensionPoints
+  removeExtensionPoints,
+  findWorkspace
 }

--- a/lib/pure-helpers.js
+++ b/lib/pure-helpers.js
@@ -43,17 +43,17 @@ function findOrgOrThrow (orgId, orgCode, workspaces) {
 }
 
 /** @private */
-function findProjectOrThrow (projectId, projectName, projects) {
+function findProjectOrThrow ({ projectId, projectName }, projects, options = { throwOnNotFound: true }) {
   // either projectId or projectName is defined
-
+  const { throwOnNotFound } = options
   const projectByName = projectName && projects.find(p => p.name === projectName)
   const projectById = projectId && projects.find(p => p.id === projectId)
 
-  if (!projectByName && !projectById) {
+  if (!projectByName && !projectById && throwOnNotFound) {
     throw new Error(`Project '${projectName || projectId}' not found.`)
   }
 
-  if (projectByName && projectById && projectById.id !== projectByName.id) {
+  if (projectByName && projectById && projectById.id !== projectByName.id && throwOnNotFound) {
     throw new Error(`Project name '${projectName}' and id '${projectId}' do not refer to the same Project.`)
   }
 
@@ -61,43 +61,21 @@ function findProjectOrThrow (projectId, projectName, projects) {
 }
 
 /** @private */
-function findWorkspaceOrThrow (workspaceId, workspaceName, workspaces) {
+function findWorkspaceOrThrow ({ workspaceId, workspaceName }, workspaces, options = { throwOnNotFound: true }) {
   // either workspaceId or workspaceName is defined
-
+  const { throwOnNotFound } = options
   const workspaceByName = workspaceName && workspaces.find(w => w.name === workspaceName)
   const workspaceById = workspaceId && workspaces.find(w => w.id === workspaceId)
 
-  if (!workspaceByName && !workspaceById) {
+  if (!workspaceByName && !workspaceById && throwOnNotFound) {
     throw new Error(`Workspace '${workspaceName || workspaceId}' not found.`)
   }
 
-  if (workspaceByName && workspaceById && workspaceById.id !== workspaceByName.id) {
+  if (workspaceByName && workspaceById && workspaceById.id !== workspaceByName.id && throwOnNotFound) {
     throw new Error(`Workspace name '${workspaceName}' and id '${workspaceId}' do not refer to the same Workspace.`)
   }
 
   return workspaceById || workspaceByName
-}
-
-/** @private
- * @returns {object | undefined} result
- * */
-
-function findWorkspace ({
-  workspaceId,
-  workspaceName
-}, workspaces) {
-  // either workspaceId or workspaceName is defined
-
-  const workspaceByName = workspaceName && workspaces.find(w => w.name === workspaceName)
-  const workspaceById = workspaceId && workspaces.find(w => w.id === workspaceId)
-
-  if (workspaceByName && workspaceById && workspaceById.id !== workspaceByName.id) {
-    throw new Error(`Workspace name '${workspaceName}' and id '${workspaceId}' do not refer to the same Workspace.`)
-  }
-
-  if (workspaceByName || workspaceById) {
-    return workspaceById || workspaceByName
-  }
 }
 
 /** @private */
@@ -307,6 +285,5 @@ module.exports = {
   enhanceWorkspaceConfiguration,
   workspaceNamesToPromptString,
   mergeExtensionPoints,
-  removeExtensionPoints,
-  findWorkspace
+  removeExtensionPoints
 }

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -679,7 +679,7 @@ describe('instance methods tests', () => {
     })
     test('with preselected id that does not match an entity', async () => {
       await expect(consoleCli.promptForSelectWorkspace(dataMocks.workspaces, { workspaceId: 'idontexist' }))
-        .rejects.toThrow('Workspace \'idontexist\' not found')
+        .resolves.toEqual(undefined)
       expect(mockPrompt.promptSelect).not.toHaveBeenCalled()
       expect(mockPrompt.promptSelectOrCreate).not.toHaveBeenCalled()
     })
@@ -720,19 +720,6 @@ describe('instance methods tests', () => {
       .toEqual(['Name', { validate: validators.validateWorkspaceName }])
     expect(mockPrompt.promptInput.mock.calls[1])
       .toEqual(['Title', { validate: validators.validateWorkspaceTitle, default: '' }])
-  })
-  test('promptForCreateWorkspaceDetails, called with default values', async () => {
-    mockPrompt.promptInput.mockResolvedValueOnce('name')
-    mockPrompt.promptInput.mockResolvedValueOnce('title')
-    const testName = 'testName'
-    const testTitle = 'testTitle'
-    await consoleCli.promptForCreateWorkspaceDetails(testName, testTitle)
-    expect(mockPrompt.promptInput).toHaveBeenCalledWith(
-      'Name', { default: testName, validate: expect.anything() }
-    )
-    expect(mockPrompt.promptInput).toHaveBeenCalledWith(
-      'Title', { default: testTitle, validate: expect.anything() }
-    )
   })
 
   describe('promptForSelectServiceProperties', () => {

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -612,9 +612,15 @@ describe('instance methods tests', () => {
       expect(mockPrompt.promptSelect).not.toHaveBeenCalled()
       expect(mockPrompt.promptSelectOrCreate).not.toHaveBeenCalled()
     })
-    test('with preselected id that does not match an entity', async () => {
-      await expect(consoleCli.promptForSelectProject(dataMocks.projects, { projectId: 'idontexist' }))
+    test('with preselected id that does not match an entity, allowCreate = false', async () => {
+      await expect(consoleCli.promptForSelectProject(dataMocks.projects, { projectId: 'idontexist' }, { allowCreate: false }))
         .rejects.toThrow('Project \'idontexist\' not found')
+      expect(mockPrompt.promptSelect).not.toHaveBeenCalled()
+      expect(mockPrompt.promptSelectOrCreate).not.toHaveBeenCalled()
+    })
+    test('with preselected id that does not match an entity, allowCreate = true', async () => {
+      await expect(consoleCli.promptForSelectProject(dataMocks.projects, { projectId: 'idontexist' }, { allowCreate: true }))
+        .resolves.toEqual(undefined)
       expect(mockPrompt.promptSelect).not.toHaveBeenCalled()
       expect(mockPrompt.promptSelectOrCreate).not.toHaveBeenCalled()
     })
@@ -677,9 +683,15 @@ describe('instance methods tests', () => {
       expect(mockPrompt.promptSelect).not.toHaveBeenCalled()
       expect(mockPrompt.promptSelectOrCreate).not.toHaveBeenCalled()
     })
-    test('with preselected id that does not match an entity', async () => {
-      await expect(consoleCli.promptForSelectWorkspace(dataMocks.workspaces, { workspaceId: 'idontexist' }))
+    test('with preselected id that does not match an entity, allowCreate = true', async () => {
+      await expect(consoleCli.promptForSelectWorkspace(dataMocks.workspaces, { workspaceId: 'idontexist' }, { allowCreate: true }))
         .resolves.toEqual(undefined)
+      expect(mockPrompt.promptSelect).not.toHaveBeenCalled()
+      expect(mockPrompt.promptSelectOrCreate).not.toHaveBeenCalled()
+    })
+    test('with preselected id that does not match an entity, allowCreate = false', async () => {
+      await expect(consoleCli.promptForSelectWorkspace(dataMocks.workspaces, { workspaceId: 'idontexist' }, { allowCreate: false }))
+        .rejects.toThrow('Workspace \'idontexist\' not found')
       expect(mockPrompt.promptSelect).not.toHaveBeenCalled()
       expect(mockPrompt.promptSelectOrCreate).not.toHaveBeenCalled()
     })

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -721,6 +721,19 @@ describe('instance methods tests', () => {
     expect(mockPrompt.promptInput.mock.calls[1])
       .toEqual(['Title', { validate: validators.validateWorkspaceTitle, default: '' }])
   })
+  test('promptForCreateWorkspaceDetails, called with default values', async () => {
+    mockPrompt.promptInput.mockResolvedValueOnce('name')
+    mockPrompt.promptInput.mockResolvedValueOnce('title')
+    const testName = 'testName'
+    const testTitle = 'testTitle'
+    await consoleCli.promptForCreateWorkspaceDetails(testName, testTitle)
+    expect(mockPrompt.promptInput).toHaveBeenCalledWith(
+      'Name', { default: testName, validate: expect.anything() }
+    )
+    expect(mockPrompt.promptInput).toHaveBeenCalledWith(
+      'Title', { default: testTitle, validate: expect.anything() }
+    )
+  })
 
   describe('promptForSelectServiceProperties', () => {
     test('select services', async () => {

--- a/test/lib/pure-helpers.test.js
+++ b/test/lib/pure-helpers.test.js
@@ -192,55 +192,75 @@ describe('findOrgOrThrow', () => {
 
 describe('findProjectOrThrow', () => {
   test('with projectId found in projects', () => {
-    expect(helpers.findProjectOrThrow(dataMocks.project.id, undefined, dataMocks.projects))
+    const data = { projectId: dataMocks.project.id, projectName: undefined }
+    expect(helpers.findProjectOrThrow(data, dataMocks.projects))
       .toEqual(dataMocks.project)
   })
   test('with projectName found in projects', () => {
-    expect(helpers.findProjectOrThrow(undefined, dataMocks.project.name, dataMocks.projects))
+    const data = { projectId: undefined, projectName: dataMocks.project.name }
+    expect(helpers.findProjectOrThrow(data, dataMocks.projects))
       .toEqual(dataMocks.project)
   })
   test('with projectName and projectId pointing to the same project', () => {
-    expect(helpers.findProjectOrThrow(dataMocks.project.id, dataMocks.project.name, dataMocks.projects))
+    const data = { projectId: dataMocks.project.id, projectName: dataMocks.project.name }
+    expect(helpers.findProjectOrThrow(data, dataMocks.projects))
       .toEqual(dataMocks.project)
   })
   test('with projectId and projectName pointing to different projects', () => {
-    expect(() => helpers.findProjectOrThrow(dataMocks.projects[0].id, dataMocks.projects[1].name, dataMocks.projects))
+    const data = { projectId: dataMocks.projects[0].id, projectName: dataMocks.projects[1].name }
+    expect(() => helpers.findProjectOrThrow(data, dataMocks.projects))
       .toThrow("Project name 'mySecondProject' and id '1234567890123456789' do not refer to the same Project.")
   })
   test('with projectId not found in projects', () => {
-    expect(() => helpers.findProjectOrThrow('iamanonexistingid', undefined, dataMocks.projects))
+    const data = { projectId: 'iamanonexistingid', projectName: undefined }
+    expect(() => helpers.findProjectOrThrow(data, dataMocks.projects))
       .toThrow("Project 'iamanonexistingid' not found.")
   })
   test('with projectId and projectName not found in projects', () => {
-    expect(() => helpers.findProjectOrThrow('iamanonexistingid', 'cannotfind', dataMocks.projects))
+    const data = { projectId: 'iamanonexistingid', projectName: 'cannotfind' }
+    expect(() => helpers.findProjectOrThrow(data, dataMocks.projects))
       .toThrow("Project 'cannotfind' not found.")
+  })
+  test('throwOnNotFound = false, return undefined', () => {
+    const data = { projectId: 'iamanonexistingid', projectName: 'cantfindName' }
+    expect(helpers.findProjectOrThrow(data, dataMocks.workspaces, { throwOnNotFound: false })).toEqual(undefined)
   })
 })
 
 describe('findWorkspaceOrThrow', () => {
   test('with workspaceId found in workspaces', () => {
-    expect(helpers.findWorkspaceOrThrow(dataMocks.workspace.id, undefined, dataMocks.workspaces))
+    const data = { workspaceId: dataMocks.workspace.id, workspaceName: undefined }
+    expect(helpers.findWorkspaceOrThrow(data, dataMocks.workspaces))
       .toEqual(dataMocks.workspace)
   })
   test('with workspaceName found in workspaces', () => {
-    expect(helpers.findWorkspaceOrThrow(undefined, dataMocks.workspace.name, dataMocks.workspaces))
+    const data = { workspaceId: undefined, workspaceName: dataMocks.workspace.name }
+    expect(helpers.findWorkspaceOrThrow(data, dataMocks.workspaces))
       .toEqual(dataMocks.workspace)
   })
   test('with workspaceId and workspaceName pointing to same workspace', () => {
-    expect(helpers.findWorkspaceOrThrow(dataMocks.workspace.id, dataMocks.workspace.name, dataMocks.workspaces))
+    const data = { workspaceId: dataMocks.workspace.id, workspaceName: dataMocks.workspace.name }
+    expect(helpers.findWorkspaceOrThrow(data, dataMocks.workspaces))
       .toEqual(dataMocks.workspace)
   })
   test('with workspace id and workspace name pointing to two different workspaces', () => {
-    expect(() => helpers.findWorkspaceOrThrow(dataMocks.workspaces[0].id, dataMocks.workspaces[1].name, dataMocks.workspaces))
+    const workspaceDetails = { workspaceId: dataMocks.workspaces[0].id, workspaceName: dataMocks.workspaces[1].name }
+    expect(() => helpers.findWorkspaceOrThrow(workspaceDetails, dataMocks.workspaces, { throwOnNotFound: true }))
       .toThrow("Workspace name 'Stage' and id '1111111111111111111' do not refer to the same Workspace.")
   })
   test('with workspace id and workspace name not found in workspaces', () => {
-    expect(() => helpers.findWorkspaceOrThrow('iamanonexistingid', 'cantfind', dataMocks.workspaces))
-      .toThrow("Workspace 'cantfind' not found.")
+    const workspaceDetails = { workspaceId: 'iamanonexistingid', workspaceName: 'cantfindName' }
+    expect(() => helpers.findWorkspaceOrThrow(workspaceDetails, dataMocks.workspaces, { throwOnNotFound: true }))
+      .toThrow("Workspace 'cantfindName' not found.")
   })
   test('with workspaceId not found in workspaces', () => {
-    expect(() => helpers.findWorkspaceOrThrow('iamanonexistingid', undefined, dataMocks.workspaces))
+    const workspaceDetails = { workspaceId: 'iamanonexistingid', workspaceName: undefined }
+    expect(() => helpers.findWorkspaceOrThrow(workspaceDetails, dataMocks.workspaces, { throwOnNotFound: true }))
       .toThrow("Workspace 'iamanonexistingid' not found.")
+  })
+  test('throwOnNotFound = false, return undefined', () => {
+    const workspaceDetails = { workspaceId: 'iamanonexistingid', workspaceName: 'cantfindName' }
+    expect(helpers.findWorkspaceOrThrow(workspaceDetails, dataMocks.workspaces, { throwOnNotFound: false })).toEqual(undefined)
   })
 })
 
@@ -267,19 +287,19 @@ describe('workspaceNamesToPromptString', () => {
 test('mergeExtensionPoints', () => {
   const newWorkspaceEndPoints = {
     endpoints: {
-      'dx/asset-compute/worker/1' : {
-        worker: "test"
+      'dx/asset-compute/worker/1': {
+        worker: 'test'
       }
     }
   }
 
   const expectedResults = {
     endpoints: {
-      'dx/asset-compute/worker/1' : {
-        worker: "test"
+      'dx/asset-compute/worker/1': {
+        worker: 'test'
       },
-      'dx/excshell/1' : {
-        view: "test"
+      'dx/excshell/1': {
+        view: 'test'
       }
     }
   }
@@ -290,16 +310,16 @@ test('mergeExtensionPoints', () => {
 test('removeExtensionPoints', () => {
   const toBeRemoved = {
     endpoints: {
-      'dx/asset-compute/worker/1' : {
-        worker: "test"
+      'dx/asset-compute/worker/1': {
+        worker: 'test'
       }
     }
   }
 
   const expectedResults = {
     endpoints: {
-      'dx/excshell/1' : {
-        view: "test"
+      'dx/excshell/1': {
+        view: 'test'
       }
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
FindOrThrow Projects/Workspaces utils functions now will not throw if the parameter throwOnNotFound: false, is passed. 
<!--- Describe your changes in detail -->
We want to be able to return `undefined` project/workspace via the `promptForSelectWorkflow`/`promptForSelectOrganization` in order to facilitate the creation flow of the entity.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

`promptForSelectWorkspace` currently throws when no workspace is found for the given `workspaceNameOrId`

Given that [ACNA-1056 PR](https://github.com/adobe/aio-cli-plugin-app/pull/498/files) allows creation of new workspaces with the provided id/name, it shouldn't throw when` { allowCreate: true }` is passed as a parameter.

Thus this gets also aligned with the prompt case that returns undefined on creation selection. This would make the library more coherent.

<!--- Why is this change required? What problem does it solve? -->


## How Has This Been Tested?
Given the [ACNA-1056 PR](https://github.com/adobe/aio-cli-plugin-app/pull/498/files) 
In an aio proiect folder, run: 

`aio app use -w notExistingWorkspace` 
-> Should prompt for creation confirmation :
 -  Should throw error on deny. 
  - Should continue with creation of the workspace.
-> It should create and switch to the workspace just created. 

  
`aio app use -w existingWorkspace` 
-> Should switch to the existing workspace.

  
`aio app use` 
-> Choose: `B. Switch to another Workspace in the current Project.`
-> Type: `+`
-> A new workspace creation confirmation
-> Enter workspace details
-> It should create and switch to the workspace just created. 
  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
