### PR TITLE
fix. checkDevTermsForOrg should check for current value.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -228,10 +228,10 @@ class LibConsoleCLI {
     spinner.start('Checking Developer Terms of Service status...')
     const res = await this.sdkClient.checkOrgDevTerms(orgId)
     spinner.stop()
-    const currentTermsAccepted = res.body.current
-    const termsAcceptedDebug = currentTermsAccepted ? 'accepted' : 'not accepted'
+    const termsAccepted = res.body.current && res.body.accepted
+    const termsAcceptedDebug = termsAccepted ? 'accepted' : 'not accepted'
     logger.debug(`Developer terms were ${termsAcceptedDebug} for ${orgId}`)
-    return currentTermsAccepted
+    return termsAccepted
   }
 
   async getDevTermsForOrg () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -228,10 +228,10 @@ class LibConsoleCLI {
     spinner.start('Checking Developer Terms of Service status...')
     const res = await this.sdkClient.checkOrgDevTerms(orgId)
     spinner.stop()
-    const termsAccepted = res.body.accepted
-    const termsAcceptedDebug = termsAccepted ? 'accepted' : 'not accepted'
+    const currentTermsAccepted = res.body.current
+    const termsAcceptedDebug = currentTermsAccepted ? 'accepted' : 'not accepted'
     logger.debug(`Developer terms were ${termsAcceptedDebug} for ${orgId}`)
-    return termsAccepted
+    return currentTermsAccepted
   }
 
   async getDevTermsForOrg () {

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -1035,8 +1035,16 @@ describe('instance methods tests', () => {
     expect(mockConsoleSDKInstance.checkOrgDevTerms).toHaveBeenCalled()
     expect(res).toEqual(true)
   })
-  test('checkDevTermsForOrg, accepted = false', async () => {
+  test('checkDevTermsForOrg, accepted = false, current = false', async () => {
     mockConsoleSDKInstance.checkOrgDevTerms.mockResolvedValue({ body: { accepted: true, current: false } })
+    const res = await consoleCli.checkDevTermsForOrg()
+    expect(mockOraObject.start).toHaveBeenCalled()
+    expect(mockOraObject.stop).toHaveBeenCalled()
+    expect(mockConsoleSDKInstance.checkOrgDevTerms).toHaveBeenCalled()
+    expect(res).toEqual(false)
+  })
+  test('checkDevTermsForOrg, accepted = false, current = true', async () => {
+    mockConsoleSDKInstance.checkOrgDevTerms.mockResolvedValue({ body: { accepted: false, current: true } })
     const res = await consoleCli.checkDevTermsForOrg()
     expect(mockOraObject.start).toHaveBeenCalled()
     expect(mockOraObject.stop).toHaveBeenCalled()

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -69,7 +69,7 @@ function setDefaultMockConsoleSdk () {
   mockConsoleSDKInstance.updateEndPointsInWorkspace.mockResolvedValue({ body: dataMocks.multipleWorkspaceEndPoints })
   mockConsoleSDKInstance.getAllExtensionPoints.mockResolvedValue({ body: dataMocks.allExtensionPoints })
   mockConsoleSDKInstance.getDevTerms.mockResolvedValue({ body: { tc: [{ text: 'some dev terms', locale: 'en' }] } })
-  mockConsoleSDKInstance.checkOrgDevTerms.mockResolvedValue({ body: { accepted: true } })
+  mockConsoleSDKInstance.checkOrgDevTerms.mockResolvedValue({ body: { accepted: true, current: true } })
   mockConsoleSDKInstance.acceptOrgDevTerms.mockResolvedValue({ body: { accepted: true, current: true } })
 }
 
@@ -1036,7 +1036,7 @@ describe('instance methods tests', () => {
     expect(res).toEqual(true)
   })
   test('checkDevTermsForOrg, accepted = false', async () => {
-    mockConsoleSDKInstance.checkOrgDevTerms.mockResolvedValue({ body: { accepted: false } })
+    mockConsoleSDKInstance.checkOrgDevTerms.mockResolvedValue({ body: { accepted: true, current: false } })
     const res = await consoleCli.checkDevTermsForOrg()
     expect(mockOraObject.start).toHaveBeenCalled()
     expect(mockOraObject.stop).toHaveBeenCalled()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Based on [aio-lib-console#32](https://github.com/adobe/aio-lib-console/pull/32/files), this method will return: 
- current : Flag for current version of Developer Terms
- accepted: Flag for accepted state

`current` value should be returned in order to validate the term's acceptance status.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
