### PR TITLE
feat: assets-11322 add aio-cli console support for public key rotation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -412,6 +412,65 @@ class LibConsoleCLI {
     return createCredentialResponse.body
   }
 
+  async getBindingsForWorkspace (orgId, project, workspace) {
+    const credential = await this.getFirstEntpCredentials(orgId, project.id, workspace)
+    const credentialId = credential && credential.id_integration
+    if (!credentialId) {
+      logger.debug('The selected workspace does not have an Enterprise Credential.')
+      return []
+    }
+    spinner.start(`Get public key bindings for Enterprise Credentials in Workspace ${workspace.name}...`)
+    const getBindingsResponse = await this.sdkClient.getBindingsForIntegration(
+      orgId,
+      credentialId
+    )
+
+    spinner.stop()
+
+    logger.debug(`Get Bindings Response: ${JSON.stringify(getBindingsResponse.body, null, 2)}`)
+    return getBindingsResponse.body
+  }
+
+  async uploadAndBindCertificate (orgId, project, workspace, publicKeyPath) {
+    const credential = await this.getFirstEntpCredentials(orgId, project.id, workspace)
+    const credentialId = credential && credential.id_integration
+    if (!credentialId) {
+      logger.debug('The selected workspace does not have an Enterprise Credential.')
+      return []
+    }
+    spinner.start(`Uploading and binding certificate to Enterprise Credentials for Workspace ${workspace.name}...`)
+    const uploadAndBindCertificateResponse = await this.sdkClient.uploadAndBindCertificate(
+      orgId,
+      credentialId,
+      fs.createReadStream(publicKeyPath)
+    )
+
+    spinner.stop()
+
+    logger.debug(`Upload and Bind Certificate Response: ${JSON.stringify(uploadAndBindCertificateResponse.body, null, 2)}`)
+    return uploadAndBindCertificateResponse.body
+  }
+
+  async deleteBindingFromWorkspace (orgId, project, workspace, binding) {
+    const credential = await this.getFirstEntpCredentials(orgId, project.id, workspace)
+    const credentialId = credential && credential.id_integration
+    if (!credentialId) {
+      logger.debug('The selected workspace does not have an Enterprise Credential.')
+      return []
+    }
+    spinner.start(`Deleting public key binding ${binding.fingerprint} from Enterprise Credentials for Workspace ${workspace.name}...`)
+    const deleteBindingResponse = await this.sdkClient.deleteBinding(
+      orgId,
+      credentialId,
+      binding.bindingId
+    )
+
+    spinner.stop()
+
+    logger.debug(`Delete binding Response: ${deleteBindingResponse.status}`)
+    return deleteBindingResponse.status === 200
+  }
+
   async getFirstEntpCredentials (orgId, projectId, workspace) {
     spinner.start(`Getting Enterprise Credentials attached to Workspace ${workspace.name}...`)
     const credentials = (await this.sdkClient.getCredentials(orgId, projectId, workspace.id)).body

--- a/lib/index.js
+++ b/lib/index.js
@@ -412,6 +412,16 @@ class LibConsoleCLI {
     return createCredentialResponse.body
   }
 
+  /**
+   * Compute SHA-1 fingerprint for the provided PEM-encoded x.509 certificate.
+   *
+   * @param {string|Buffer} pemCert cert string
+   * @returns {{ certificateFingerprint: string }} fingerprint
+   */
+  async getCertificateFingerprint (pemCert) {
+    return certPlugin.fingerprint(pemCert)
+  }
+
   async getBindingsForWorkspace (orgId, project, workspace) {
     const credential = await this.getFirstEntpCredentials(orgId, project.id, workspace)
     const credentialId = credential && credential.id_integration

--- a/lib/index.js
+++ b/lib/index.js
@@ -422,6 +422,20 @@ class LibConsoleCLI {
     return certPlugin.fingerprint(pemCert)
   }
 
+  /**
+   * Get public key certificate bindings for the Service Account credentials
+   * linked to the provided workspace.
+   *
+   * @param {string} orgId sequential orgId
+   * @param {{ id: string }} project project object from getProjects
+   * @param {{ id: string, name: string }} workspace object from getWorkspace
+   * @returns {{
+   *            bindingId: string,
+   *            orgId: string,
+   *            technicalAccountId: string,
+   *            certificateFingerprint: string,
+   *            notAfter: number }[]} array of bindings
+   */
   async getBindingsForWorkspace (orgId, project, workspace) {
     const credential = await this.getFirstEntpCredentials(orgId, project.id, workspace)
     const credentialId = credential && credential.id_integration
@@ -441,6 +455,21 @@ class LibConsoleCLI {
     return getBindingsResponse.body
   }
 
+  /**
+   * Upload and bind the provided public key certificate file to the Service Account credentials
+   * linked to the provided workspace.
+   *
+   * @param {string} orgId sequential orgId
+   * @param {{ id: string }} project project object from getProjects
+   * @param {{ id: string, name: string }} workspace object from getWorkspace
+   * @param {string} publicKeyPath path to public key certificate file
+   * @returns {{
+   *            bindingId: string,
+   *            orgId: string,
+   *            technicalAccountId: string,
+   *            certificateFingerprint: string,
+   *            notAfter: number }[]} array containing the added binding
+   */
   async uploadAndBindCertificateToWorkspace (orgId, project, workspace, publicKeyPath) {
     const credential = await this.getFirstEntpCredentials(orgId, project.id, workspace)
     const credentialId = credential && credential.id_integration
@@ -461,6 +490,16 @@ class LibConsoleCLI {
     return uploadAndBindCertificateResponse.body
   }
 
+  /**
+   * Delete the provided certificate binding from the Service Account credentials
+   * linked to the provided workspace.
+   *
+   * @param {string} orgId sequential orgId
+   * @param {{ id: string }} project project object from getProjects
+   * @param {{ id: string, name: string }} workspace object from getWorkspace
+   * @param {{ bindingId: string, certificateFingerprint: string }} binding binding from getBindingsForWorkspace
+   * @returns {boolean} true if the binding existed and was deleted by this operation
+   */
   async deleteBindingFromWorkspace (orgId, project, workspace, binding) {
     const credential = await this.getFirstEntpCredentials(orgId, project.id, workspace)
     const credentialId = credential && credential.id_integration
@@ -468,7 +507,7 @@ class LibConsoleCLI {
       logger.debug('The selected workspace does not have an Enterprise Credential.')
       return false
     }
-    spinner.start(`Deleting public key binding ${binding.fingerprint} from Enterprise Credentials for Workspace ${workspace.name}...`)
+    spinner.start(`Deleting public key binding ${binding.certificateFingerprint} from Enterprise Credentials for Workspace ${workspace.name}...`)
     const deleteBindingResponse = await this.sdkClient.deleteBinding(
       orgId,
       credentialId,

--- a/lib/index.js
+++ b/lib/index.js
@@ -441,7 +441,7 @@ class LibConsoleCLI {
     return getBindingsResponse.body
   }
 
-  async uploadAndBindCertificate (orgId, project, workspace, publicKeyPath) {
+  async uploadAndBindCertificateToWorkspace (orgId, project, workspace, publicKeyPath) {
     const credential = await this.getFirstEntpCredentials(orgId, project.id, workspace)
     const credentialId = credential && credential.id_integration
     if (!credentialId) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -466,7 +466,7 @@ class LibConsoleCLI {
     const credentialId = credential && credential.id_integration
     if (!credentialId) {
       logger.debug('The selected workspace does not have an Enterprise Credential.')
-      return []
+      return false
     }
     spinner.start(`Deleting public key binding ${binding.fingerprint} from Enterprise Credentials for Workspace ${workspace.name}...`)
     const deleteBindingResponse = await this.sdkClient.deleteBinding(

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@adobe/aio-cli-plugin-certificate": "^0.3.1",
-    "@adobe/aio-lib-console": "^3.1.0",
+    "@adobe/aio-lib-console": "^3.2.0",
     "@adobe/aio-lib-core-logging": "^1.2.0",
     "fs-extra": "^10",
     "fuzzy": "^0.1.3",

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -195,7 +195,7 @@ test('instance methods definitions', async () => {
   expect(typeof consoleCli.createEnterpriseCredentials).toBe('function')
   expect(typeof consoleCli.createProject).toBe('function')
   expect(typeof consoleCli.createWorkspace).toBe('function')
-  expect(typeof consoleCli.uploadAndBindCertificate).toBe('function')
+  expect(typeof consoleCli.uploadAndBindCertificateToWorkspace).toBe('function')
   expect(typeof consoleCli.deleteBindingFromWorkspace).toBe('function')
   // prompt methods
   expect(typeof consoleCli.promptForSelectServiceProperties).toBe('function')
@@ -1117,7 +1117,7 @@ describe('instance methods tests', () => {
     const res2 = await consoleCli.deleteBindingFromWorkspace('testOrg', { id: 'testPrj' }, { id: 'testWS' }, binding)
     expect(res2).toBe(false)
   })
-  test('uploadAndBindCertificateNoCredential', async () => {
+  test('uploadAndBindCertificateToWorkspaceNoCredential', async () => {
     const binding = {
       bindingId: '827514',
       certificateFingerprint: '38f65e26bd3869ec3ca029cc0b3df98de29172b9',
@@ -1125,10 +1125,10 @@ describe('instance methods tests', () => {
     }
     mockConsoleSDKInstance.uploadAndBindCertificate.mockResolvedValue({ body: [binding] })
     mockConsoleSDKInstance.getCredentials.mockResolvedValue({ body: [] })
-    const res = await consoleCli.uploadAndBindCertificate('testOrg', { id: 'testPrj' }, { id: 'testWS' })
+    const res = await consoleCli.uploadAndBindCertificateToWorkspace('testOrg', { id: 'testPrj' }, { id: 'testWS' })
     expect(res).toEqual([])
   })
-  test('uploadAndBindCertificate', async () => {
+  test('uploadAndBindCertificateToWorkspace', async () => {
     const binding = {
       bindingId: '827514',
       certificateFingerprint: '38f65e26bd3869ec3ca029cc0b3df98de29172b9',
@@ -1136,7 +1136,7 @@ describe('instance methods tests', () => {
     }
     mockConsoleSDKInstance.uploadAndBindCertificate.mockResolvedValue({ body: [binding] })
     mockConsoleSDKInstance.getCredentials.mockResolvedValue({ body: [{ id_integration: 'testIntId', flow_type: 'entp', integration_type: 'service' }] })
-    const res = await consoleCli.uploadAndBindCertificate('testOrg', { id: 'testPrj' }, { id: 'testWS' })
+    const res = await consoleCli.uploadAndBindCertificateToWorkspace('testOrg', { id: 'testPrj' }, { id: 'testWS' })
     expect(res).toEqual([binding])
   })
 })

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -37,7 +37,10 @@ const mockConsoleSDKInstance = {
   getAllExtensionPoints: jest.fn(),
   checkOrgDevTerms: jest.fn(),
   getDevTerms: jest.fn(),
-  acceptOrgDevTerms: jest.fn()
+  acceptOrgDevTerms: jest.fn(),
+  getBindingsForIntegration: jest.fn(),
+  uploadAndBindCertificate: jest.fn(),
+  deleteBinding: jest.fn()
 }
 consoleSDK.init.mockResolvedValue(mockConsoleSDKInstance)
 /** @private */
@@ -71,6 +74,8 @@ function setDefaultMockConsoleSdk () {
   mockConsoleSDKInstance.getDevTerms.mockResolvedValue({ body: { tc: [{ text: 'some dev terms', locale: 'en' }] } })
   mockConsoleSDKInstance.checkOrgDevTerms.mockResolvedValue({ body: { accepted: true, current: true } })
   mockConsoleSDKInstance.acceptOrgDevTerms.mockResolvedValue({ body: { accepted: true, current: true } })
+  mockConsoleSDKInstance.getBindingsForIntegration.mockResolvedValue({ body: [] })
+  mockConsoleSDKInstance.uploadAndBindCertificate.mockResolvedValue({ body: {} })
 }
 
 // mock prompts
@@ -180,11 +185,14 @@ test('instance methods definitions', async () => {
   expect(typeof consoleCli.getWorkspaces).toBe('function')
   expect(typeof consoleCli.getServicePropertiesFromWorkspace).toBe('function')
   expect(typeof consoleCli.getWorkspaceConfig).toBe('function')
+  expect(typeof consoleCli.getBindingsForWorkspace).toBe('function')
   // wr console api methods
   expect(typeof consoleCli.subscribeToServices).toBe('function')
   expect(typeof consoleCli.createEnterpriseCredentials).toBe('function')
   expect(typeof consoleCli.createProject).toBe('function')
   expect(typeof consoleCli.createWorkspace).toBe('function')
+  expect(typeof consoleCli.uploadAndBindCertificate).toBe('function')
+  expect(typeof consoleCli.deleteBindingFromWorkspace).toBe('function')
   // prompt methods
   expect(typeof consoleCli.promptForSelectServiceProperties).toBe('function')
   expect(typeof consoleCli.promptForServiceSubscriptionsOperation).toBe('function')
@@ -1051,5 +1059,11 @@ describe('instance methods tests', () => {
     expect(mockOraObject.stop).toHaveBeenCalled()
     expect(mockConsoleSDKInstance.checkOrgDevTerms).toHaveBeenCalled()
     expect(res).toEqual(false)
+  })
+  test('getBindingsForWorkspace', async () => {
+    mockConsoleSDKInstance.getBindingsForIntegration.mockResolvedValue({ body: [] })
+    mockConsoleSDKInstance.getCredentials.mockResolvedValue({ body: [{ id_integration: 'testIntId' }] })
+    const res = await consoleCli.getBindingsForWorkspace('testOrg', { id: 'testPrj' }, { id: 'testWS' })
+    expect(res).toEqual([])
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add four functions to LibConsoleCLI:

- `getBindingsForWorkspace(orgId, project, workspace)`: retrieve the list of certificate bindings for the selected workspace
- `uploadAndBindCertificateToWorkspace(orgId, project, workspace, publicKeyPath)`: upload and bind a public key certificate to the service account of the selected workspace 
- `deleteBindingFromWorkspace(orgId, project, workspace, binding)`: delete a binding (retrieved from getBindingsForWorkspace) from the selected workspace service account
- `getCertificateFingerprint(pemCert)`: compute x509 fingerprint for provided public key certificate

These functions provide necessary support for `aio console:publickey` commands introduced by https://github.com/adobe/aio-cli-plugin-console/pull/173

## Related Issue

https://jira.corp.adobe.com/browse/ASSETS-11322

## Blocked by 

~https://jira.corp.adobe.com/browse/IOC-4292~

~https://github.com/adobe/aio-lib-console/pull/33~

## Motivation and Context

`aio console` should support workspace public key rotation, in combination with `aio certificate:generate`.

## How Has This Been Tested?

Tested locally with npm linked branches of:

@adobe/aio-lib-console
@adobe/aio-cli-lib-console
@adobe/aio-cli-plugin-console

<img width="757" alt="image" src="https://user-images.githubusercontent.com/524972/172032034-45e5d5d2-0bce-4a40-a227-4e977121b6f0.png">

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/524972/171711359-1512cced-634d-40d7-8e47-b3f8f3a92fb4.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
