### PR TITLE
fix: ASSETS-11322. bump aio-cli-plugin-certificate to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
-    "@adobe/aio-cli-plugin-certificate": "^0.3.1",
+    "@adobe/aio-cli-plugin-certificate": "^0.4.0",
     "@adobe/aio-lib-console": "^3.2.0",
     "@adobe/aio-lib-core-logging": "^1.2.0",
     "fs-extra": "^10",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bumps the version of @adobe/aio-cli-plugin-certificate to 0.4.0 for the `:fingerprint` command added in https://github.com/adobe/aio-cli-plugin-certificate/pull/22 .

## Related Issue

https://jira.corp.adobe.com/browse/ASSETS-11322

## How Has This Been Tested?

1. npm test using unlinked and reinstalled aio-cli-plugin-certificate. 

2. Ran command: `aio console:publickey:upload` using a real project workspace and a real certificate.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/524972/173709340-9154d966-8e60-4e0b-97dd-c595bb4456cf.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
