### PR TITLE
Add support for fetching project and application extensions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,6 +96,13 @@ class LibConsoleCLI {
     return projects
   }
 
+  /**
+   * Retrieves project details from the Console APi
+   *
+   * @param {*} orgId Organization AMS ID
+   * @param {*} projectId Console project ID
+   * @returns {object} Project metadata
+   */
   async getProject (orgId, projectId) {
     spinner.start('Getting Project...')
     const project = (await this.sdkClient.getProject(orgId, projectId)).body

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,6 +96,14 @@ class LibConsoleCLI {
     return projects
   }
 
+  async getProject (orgId, projectId) {
+    spinner.start('Getting Project...')
+    const project = (await this.sdkClient.getProject(orgId, projectId)).body
+    spinner.stop()
+    logger.debug(`Get Project response for Org ${orgId}: ${JSON.stringify(project, null, 2)}`)
+    return project
+  }
+
   /**
    * Retrieves application extensions from the extension registry API
    *

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,6 +96,21 @@ class LibConsoleCLI {
     return projects
   }
 
+  /**
+   * Retrieves application extensions from the extension registry API
+   *
+   * @param {*} orgId Organization AMS ID
+   * @param {*} appId App Builder application ID
+   * @returns {object} Extension point metadata
+   */
+  async getApplicationExtensions (orgId, appId) {
+    spinner.start('Getting Application Extensions...')
+    const extensionPoints = (await this.sdkClient.getApplicationExtensions(orgId, appId)).body.data
+    spinner.stop()
+    logger.debug(`Get Application Extensions response for Org ${orgId}: ${JSON.stringify(extensionPoints, null, 2)}`)
+    return extensionPoints
+  }
+
   async promptForSelectProject (projects, data = { projectId: undefined, projectName: undefined }, options = { allowCreate: false }) {
     let selectedProject
     if (data.projectId || data.projectName) {

--- a/test/data-mocks.js
+++ b/test/data-mocks.js
@@ -526,6 +526,82 @@ const allExtensionPoints = [
   }
 ]
 
+const applicationExtensions = {
+  data: [
+    {
+      appId: 'appid',
+      name: 'name',
+      title: 'title',
+      publisherId: 'publisherId',
+      status: 'PUBLISHED',
+      isPrivate: null,
+      description: 'description',
+      version: null,
+      workspaces: [
+        {
+          id: 'id1',
+          name: 'Production'
+        },
+        {
+          id: 'id2',
+          name: 'Stage'
+        }
+      ],
+      lifecycle: {
+        created: {
+          by: {
+            guid: 'guid@AdobeID'
+          },
+          notes: null,
+          on: '2022-06-10T20:19:29.997+0000'
+        },
+        lastModified: {
+          by: {
+            guid: 'guid@AdobeID'
+          },
+          notes: null,
+          on: '2022-07-13T18:11:55.963+0000'
+        },
+        submitted: {
+          by: {
+            guid: 'guid@AdobeID'
+          },
+          notes: 'notes',
+          on: '2022-06-10T20:35:28.085+0000'
+        },
+        reviewed: {
+          by: {
+            guid: 'guid@AdobeID'
+          },
+          notes: 'notes',
+          on: '2022-07-13T18:11:55.745+0000'
+        },
+        published: {
+          by: {
+            guid: 'guid@AdobeID'
+          },
+          notes: null,
+          on: '2022-07-13T18:11:55.963+0000'
+        }
+      },
+      support: {
+        email: 'person@adobe.com',
+        contact: null,
+        website: null
+      },
+      icon: {
+        id: 'id',
+        name: 'name.png',
+        width: '512',
+        height: '512',
+        size: '50383',
+        link: 'link'
+      },
+      media: null
+    }
+  ]
+}
+
 module.exports = {
   organizations,
   projects,
@@ -545,5 +621,6 @@ module.exports = {
   subscribeServicesPayload,
   promptChoices,
   baseWorkspaceEndPoints,
-  multipleWorkspaceEndPoints
+  multipleWorkspaceEndPoints,
+  applicationExtensions
 }

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -187,6 +187,7 @@ test('instance methods definitions', async () => {
   expect(typeof consoleCli.getFirstEntpCredentials).toBe('function')
   expect(typeof consoleCli.getOrganizations).toBe('function')
   expect(typeof consoleCli.getProjects).toBe('function')
+  expect(typeof consoleCli.getProject).toBe('function')
   expect(typeof consoleCli.getApplicationExtensions).toBe('function')
   expect(typeof consoleCli.getWorkspaces).toBe('function')
   expect(typeof consoleCli.getServicePropertiesFromWorkspace).toBe('function')
@@ -231,6 +232,14 @@ describe('instance methods tests', () => {
     const projects = await consoleCli.getProjects('orgid')
     expect(projects).toEqual(dataMocks.projects)
     expect(mockConsoleSDKInstance.getProjectsForOrg).toHaveBeenCalledWith('orgid')
+    expect(mockOraObject.start).toHaveBeenCalled()
+    expect(mockOraObject.stop).toHaveBeenCalled()
+  })
+
+  test('getProject', async () => {
+    const project = await consoleCli.getProject('orgid', dataMocks.project.id)
+    expect(project).toEqual(dataMocks.project)
+    expect(mockConsoleSDKInstance.getProject).toHaveBeenCalledWith('orgid', dataMocks.project.id)
     expect(mockOraObject.start).toHaveBeenCalled()
     expect(mockOraObject.stop).toHaveBeenCalled()
   })

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -35,6 +35,7 @@ const mockConsoleSDKInstance = {
   getEndPointsInWorkspace: jest.fn(),
   updateEndPointsInWorkspace: jest.fn(),
   getAllExtensionPoints: jest.fn(),
+  getApplicationExtensions: jest.fn(),
   checkOrgDevTerms: jest.fn(),
   getDevTerms: jest.fn(),
   acceptOrgDevTerms: jest.fn(),
@@ -71,6 +72,7 @@ function setDefaultMockConsoleSdk () {
   mockConsoleSDKInstance.getEndPointsInWorkspace.mockResolvedValue({ body: dataMocks.baseWorkspaceEndPoints })
   mockConsoleSDKInstance.updateEndPointsInWorkspace.mockResolvedValue({ body: dataMocks.multipleWorkspaceEndPoints })
   mockConsoleSDKInstance.getAllExtensionPoints.mockResolvedValue({ body: dataMocks.allExtensionPoints })
+  mockConsoleSDKInstance.getApplicationExtensions.mockResolvedValue({ body: dataMocks.applicationExtensions })
   mockConsoleSDKInstance.getDevTerms.mockResolvedValue({ body: { tc: [{ text: 'some dev terms', locale: 'en' }] } })
   mockConsoleSDKInstance.checkOrgDevTerms.mockResolvedValue({ body: { accepted: true, current: true } })
   mockConsoleSDKInstance.acceptOrgDevTerms.mockResolvedValue({ body: { accepted: true, current: true } })
@@ -185,6 +187,7 @@ test('instance methods definitions', async () => {
   expect(typeof consoleCli.getFirstEntpCredentials).toBe('function')
   expect(typeof consoleCli.getOrganizations).toBe('function')
   expect(typeof consoleCli.getProjects).toBe('function')
+  expect(typeof consoleCli.getApplicationExtensions).toBe('function')
   expect(typeof consoleCli.getWorkspaces).toBe('function')
   expect(typeof consoleCli.getServicePropertiesFromWorkspace).toBe('function')
   expect(typeof consoleCli.getWorkspaceConfig).toBe('function')
@@ -228,6 +231,14 @@ describe('instance methods tests', () => {
     const projects = await consoleCli.getProjects('orgid')
     expect(projects).toEqual(dataMocks.projects)
     expect(mockConsoleSDKInstance.getProjectsForOrg).toHaveBeenCalledWith('orgid')
+    expect(mockOraObject.start).toHaveBeenCalled()
+    expect(mockOraObject.stop).toHaveBeenCalled()
+  })
+
+  test('getApplicationExtensions', async () => {
+    const applicationExtensions = await consoleCli.getApplicationExtensions('orgid', 'appid')
+    expect(applicationExtensions).toEqual(dataMocks.applicationExtensions.data)
+    expect(mockConsoleSDKInstance.getApplicationExtensions).toHaveBeenCalledWith('orgid', 'appid')
     expect(mockOraObject.start).toHaveBeenCalled()
     expect(mockOraObject.stop).toHaveBeenCalled()
   })


### PR DESCRIPTION
This pull request proposes adding support to this library for fetching project details and application extensions from the Console API. 

## Description

Add implemntation for fetching project details and the new application extension integration [here](https://github.com/adobe/aio-lib-console/pull/38). These functions are consumed by the app plugin in order to determine a project's `status` so we can make it more difficult to overwrite a published Production App Builder application. 

## Related Issue

## Motivation and Context

To more comprehensively integrate with the Console API and to make it harder to overwrite a published Production App Builder application. 

## How Has This Been Tested?

Tested locally with `npm run test` and linked version of `aio-lib-console`. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x]  My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
