### PR TITLE
feat: support migration credentials

### DIFF
--- a/lib/pure-helpers.js
+++ b/lib/pure-helpers.js
@@ -124,12 +124,12 @@ function filterEnabledServices (services) {
 
 /** @private */
 function findFirstEntpCredential (credentials) {
-  return credentials.find(c => c.flow_type === 'entp' && c.integration_type === 'service')
+  return credentials.find(c => c.flow_type === 'entp' && (c.integration_type === 'service' || c.integration_type === 'oauth_server_to_server_migrate'))
 }
 
 /** @private */
 function findFirstOAuthServerToServerCredential (credentials) {
-  return credentials.find(c => c.flow_type === 'entp' && c.integration_type === 'oauth_server_to_server')
+  return credentials.find(c => c.flow_type === 'entp' && (c.integration_type === 'oauth_server_to_server' || c.integration_type === 'oauth_server_to_server_migrate'))
 }
 
 /** @private */


### PR DESCRIPTION
## Description

When a workspace is undergoing credential migration, we get one credential back from the Console API that is of type `oauth_server_to_server_migrate`, this PR adds support for that case

## Related Issue

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- npm run test 
- locally linked app plugin with code changes

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
