### PR TITLE
Adds logic to conditionally retrieve either OAuth or JWT credentials

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -645,7 +645,7 @@ class LibConsoleCLI {
       return this.getFirstEntpCredentials(orgId, projectId, workspace)
     }
   }
-
+  
   async getWorkspaceConfig (orgId, projectId, workspaceId, supportedServices = null) {
     spinner.start('Downloading Workspace config...')
     let json = (await this.sdkClient.downloadWorkspaceJson(orgId, projectId, workspaceId)).body

--- a/lib/index.js
+++ b/lib/index.js
@@ -637,6 +637,15 @@ class LibConsoleCLI {
     return helpers.findFirstOAuthServerToServerCredential(credentials)
   }
 
+  async getWorkspaceCreds(orgId, projectId, workspace){
+    const oauthCreds = await this.getFirstOAuthServerToServerCredentials(orgId, projectId, workspace);
+    if (oauthCreds != undefined) {
+      return oauthCreds
+    } else {
+      return this.getFirstEntpCredentials(orgId, projectId, workspace);
+    }
+  }
+  
   async getWorkspaceConfig (orgId, projectId, workspaceId, supportedServices = null) {
     spinner.start('Downloading Workspace config...')
     let json = (await this.sdkClient.downloadWorkspaceJson(orgId, projectId, workspaceId)).body

--- a/lib/index.js
+++ b/lib/index.js
@@ -637,15 +637,15 @@ class LibConsoleCLI {
     return helpers.findFirstOAuthServerToServerCredential(credentials)
   }
 
-  async getWorkspaceCreds(orgId, projectId, workspace){
-    const oauthCreds = await this.getFirstOAuthServerToServerCredentials(orgId, projectId, workspace);
-    if (oauthCreds != undefined) {
+  async getWorkspaceCreds (orgId, projectId, workspace) {
+    const oauthCreds = await this.getFirstOAuthServerToServerCredentials(orgId, projectId, workspace)
+    if (oauthCreds !== undefined) {
       return oauthCreds
     } else {
-      return this.getFirstEntpCredentials(orgId, projectId, workspace);
+      return this.getFirstEntpCredentials(orgId, projectId, workspace)
     }
   }
-  
+
   async getWorkspaceConfig (orgId, projectId, workspaceId, supportedServices = null) {
     spinner.start('Downloading Workspace config...')
     let json = (await this.sdkClient.downloadWorkspaceJson(orgId, projectId, workspaceId)).body


### PR DESCRIPTION
The proposed changes will allow for the successful retrieval of either OAuth or JWT credentials through composition, so that App Builder template developers don't have the need to hardcode in the template which credential to retrieve. 

## Description

The new changes add conditional logic to look for OAuth credentials, and if such credentials are undefined, it will look for the JWT ones. This change will also make room for future auth providers to be added into the conditional. 

## Related Issue

https://github.com/adobe/commerce-events-ext-tpl/pull/6

## Motivation and Context

This update will benefit App Builder template developers by removing the requirement to hard code credentials in each template, whether existing or new. This change significantly reduces the need for hardcoded information in templates that support multiple authentication protocols.

## How Has This Been Tested?

These changes were tested specifically with `_commerce-events-ext-tpl_` commerce template. With the proposed additional code, App Builder apps were successfully initialized and deployed for projects using both JWT and OAuth credentials, including half-way the migration process from JWT to OAuth. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
