### PR TITLE
Adds conditional logic for the retrieval of credentials

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -637,13 +637,12 @@ class LibConsoleCLI {
     return helpers.findFirstOAuthServerToServerCredential(credentials)
   }
 
-  async getWorkspaceCreds (orgId, projectId, workspace) {
+  async getWorkspaceCredential (orgId, projectId, workspace) {
     const oauthCreds = await this.getFirstOAuthServerToServerCredentials(orgId, projectId, workspace)
-    const jwtCreds = await this.getFirstEntpCredentials(orgId, projectId, workspace)
     if (oauthCreds !== undefined) {
       return oauthCreds
     } else {
-      return jwtCreds
+      return this.getFirstEntpCredentials(orgId, projectId, workspace)
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -639,10 +639,11 @@ class LibConsoleCLI {
 
   async getWorkspaceCreds (orgId, projectId, workspace) {
     const oauthCreds = await this.getFirstOAuthServerToServerCredentials(orgId, projectId, workspace)
+    const jwtCreds = await this.getFirstEntpCredentials(orgId, projectId, workspace)
     if (oauthCreds !== undefined) {
       return oauthCreds
     } else {
-      return this.getFirstEntpCredentials(orgId, projectId, workspace)
+      return jwtCreds
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -637,6 +637,15 @@ class LibConsoleCLI {
     return helpers.findFirstOAuthServerToServerCredential(credentials)
   }
 
+  async getWorkspaceCreds (orgId, projectId, workspace) {
+    const oauthCreds = await this.getFirstOAuthServerToServerCredentials(orgId, projectId, workspace)
+    if (oauthCreds !== undefined) {
+      return oauthCreds
+    } else {
+      return this.getFirstEntpCredentials(orgId, projectId, workspace)
+    }
+  }
+
   async getWorkspaceConfig (orgId, projectId, workspaceId, supportedServices = null) {
     spinner.start('Downloading Workspace config...')
     let json = (await this.sdkClient.downloadWorkspaceJson(orgId, projectId, workspaceId)).body

--- a/lib/index.js
+++ b/lib/index.js
@@ -637,7 +637,7 @@ class LibConsoleCLI {
     return helpers.findFirstOAuthServerToServerCredential(credentials)
   }
 
-  async getWorkspaceCredential (orgId, projectId, workspace) {
+  async getFirstWorkspaceCredential (orgId, projectId, workspace) {
     const oauthCreds = await this.getFirstOAuthServerToServerCredentials(orgId, projectId, workspace)
     if (oauthCreds !== undefined) {
       return oauthCreds

--- a/lib/index.js
+++ b/lib/index.js
@@ -638,12 +638,20 @@ class LibConsoleCLI {
   }
 
   async getFirstWorkspaceCredential (orgId, projectId, workspace) {
-    const oauthCreds = await this.getFirstOAuthServerToServerCredentials(orgId, projectId, workspace)
+    spinner.start(`Getting Credentials for Workspace ${workspace.name}...`)
+    const credentials = (await this.sdkClient.getCredentials(orgId, projectId, workspace.id)).body
+    spinner.stop()
+    const oauthCreds = helpers.findFirstOAuthServerToServerCredential(credentials)
     if (oauthCreds !== undefined) {
+      logger.debug(`OAuth Server-to-Server Credentials found: ${JSON.stringify(oauthCreds, null, 2)}`)
       return oauthCreds
-    } else {
-      return this.getFirstEntpCredentials(orgId, projectId, workspace)
     }
+    const entpCreds = helpers.findFirstEntpCredential(credentials)
+    if (entpCreds !== undefined) {
+      logger.debug(`Enterprise Credentials found: ${JSON.stringify(entpCreds, null, 2)}`)
+      return entpCreds
+    }
+    logger.debug(`No valid credentials found for Workspace ${workspace.name}`)
   }
 
   async getWorkspaceConfig (orgId, projectId, workspaceId, supportedServices = null) {

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -198,6 +198,7 @@ test('instance methods definitions', async () => {
   expect(typeof consoleCli.getWorkspaceConfig).toBe('function')
   expect(typeof consoleCli.getBindingsForWorkspace).toBe('function')
   expect(typeof consoleCli.getCertificateFingerprint).toBe('function')
+  expect(typeof consoleCli.getFirstWorkspaceCredential).toBe('function')
   // wr console api methods
   expect(typeof consoleCli.subscribeToServices).toBe('function')
   expect(typeof consoleCli.subscribeToServicesWithCredentialType).toBe('function')
@@ -618,9 +619,9 @@ describe('instance methods tests', () => {
     })
   })
 
-  describe('getWorkspaceCredential', () => {
+  describe('getFirstWorkspaceCredential', () => {
     test('returns OAuth credentials when available', async () => {
-      const ret = await consoleCli.getWorkspaceCredential(
+      const ret = await consoleCli.getFirstWorkspaceCredential(
         dataMocks.org.id,
         dataMocks.project.id,
         dataMocks.workspace
@@ -634,7 +635,7 @@ describe('instance methods tests', () => {
     })
     test('returns JWT credentials when OAuth credentials are not available', async () => {
       mockConsoleSDKInstance.getCredentials.mockResolvedValue({ body: dataMocks.integrations.slice(0, 3) })
-      const ret = await consoleCli.getWorkspaceCredential(
+      const ret = await consoleCli.getFirstWorkspaceCredential(
         dataMocks.org.id,
         dataMocks.project.id,
         dataMocks.workspace
@@ -648,7 +649,7 @@ describe('instance methods tests', () => {
     })
     test('returns undefined when no credentials are available', async () => {
       mockConsoleSDKInstance.getCredentials.mockResolvedValue({ body: [] })
-      const ret = await consoleCli.getWorkspaceCredential(
+      const ret = await consoleCli.getFirstWorkspaceCredential(
         dataMocks.org.id,
         dataMocks.project.id,
         dataMocks.workspace

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -42,9 +42,7 @@ const mockConsoleSDKInstance = {
   acceptOrgDevTerms: jest.fn(),
   getBindingsForIntegration: jest.fn(),
   uploadAndBindCertificate: jest.fn(),
-  deleteBinding: jest.fn(),
-  getFirstOAuthServerToServerCredentials: jest.fn(),
-  getFirstEntpCredentials: jest.fn()
+  deleteBinding: jest.fn()
 }
 consoleSDK.init.mockResolvedValue(mockConsoleSDKInstance)
 /** @private */
@@ -620,10 +618,9 @@ describe('instance methods tests', () => {
     })
   })
 
-  describe('getWorkspaceCreds', () => {
+  describe('getWorkspaceCredential', () => {
     test('returns OAuth credentials when available', async () => {
-      mockConsoleSDKInstance.getFirstOAuthServerToServerCredentials.mockResolvedValue(dataMocks.integrations[4])
-      const ret = await consoleCli.getWorkspaceCreds(
+      const ret = await consoleCli.getWorkspaceCredential(
         dataMocks.org.id,
         dataMocks.project.id,
         dataMocks.workspace
@@ -634,11 +631,10 @@ describe('instance methods tests', () => {
         dataMocks.project.id,
         dataMocks.workspace.id
       )
-      expect(mockConsoleSDKInstance.getFirstEntpCredentials).not.toHaveBeenCalled()
     })
     test('returns JWT credentials when OAuth credentials are not available', async () => {
-      mockConsoleSDKInstance.getCredentials.mockResolvedValue(dataMocks.integrations[2])
-      const ret = await consoleCli.getWorkspaceCreds(
+      mockConsoleSDKInstance.getCredentials.mockResolvedValue({ body: dataMocks.integrations.slice(0, 3) })
+      const ret = await consoleCli.getWorkspaceCredential(
         dataMocks.org.id,
         dataMocks.project.id,
         dataMocks.workspace
@@ -649,11 +645,10 @@ describe('instance methods tests', () => {
         dataMocks.project.id,
         dataMocks.workspace.id
       )
-      expect(mockConsoleSDKInstance.getFirstOAuthServerToServerCredentials).not.toHaveBeenCalled()
     })
     test('returns undefined when no credentials are available', async () => {
       mockConsoleSDKInstance.getCredentials.mockResolvedValue({ body: [] })
-      const ret = await consoleCli.getWorkspaceCreds(
+      const ret = await consoleCli.getWorkspaceCredential(
         dataMocks.org.id,
         dataMocks.project.id,
         dataMocks.workspace

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -42,7 +42,9 @@ const mockConsoleSDKInstance = {
   acceptOrgDevTerms: jest.fn(),
   getBindingsForIntegration: jest.fn(),
   uploadAndBindCertificate: jest.fn(),
-  deleteBinding: jest.fn()
+  deleteBinding: jest.fn(),
+  getFirstOAuthServerToServerCredentials: jest.fn(),
+  getFirstEntpCredentials: jest.fn()
 }
 consoleSDK.init.mockResolvedValue(mockConsoleSDKInstance)
 /** @private */
@@ -605,6 +607,53 @@ describe('instance methods tests', () => {
     test('when there are none', async () => {
       mockConsoleSDKInstance.getCredentials.mockResolvedValue({ body: [] })
       const ret = await consoleCli.getFirstEntpCredentials(
+        dataMocks.org.id,
+        dataMocks.project.id,
+        dataMocks.workspace
+      )
+      expect(ret).toEqual(undefined)
+      expect(mockConsoleSDKInstance.getCredentials).toHaveBeenCalledWith(
+        dataMocks.org.id,
+        dataMocks.project.id,
+        dataMocks.workspace.id
+      )
+    })
+  })
+
+  describe('getWorkspaceCreds', () => {
+    test('returns OAuth credentials when available', async () => {
+      mockConsoleSDKInstance.getFirstOAuthServerToServerCredentials.mockResolvedValue(dataMocks.integrations[4])
+      const ret = await consoleCli.getWorkspaceCreds(
+        dataMocks.org.id,
+        dataMocks.project.id,
+        dataMocks.workspace
+      )
+      expect(ret).toEqual(dataMocks.integrations[4])
+      expect(mockConsoleSDKInstance.getCredentials).toHaveBeenCalledWith(
+        dataMocks.org.id,
+        dataMocks.project.id,
+        dataMocks.workspace.id
+      )
+      expect(mockConsoleSDKInstance.getFirstEntpCredentials).not.toHaveBeenCalled()
+    })
+    test('returns JWT credentials when OAuth credentials are not available', async () => {
+      mockConsoleSDKInstance.getCredentials.mockResolvedValue(dataMocks.integrations[2])
+      const ret = await consoleCli.getWorkspaceCreds(
+        dataMocks.org.id,
+        dataMocks.project.id,
+        dataMocks.workspace
+      )
+      expect(ret).toEqual(dataMocks.integrations[2])
+      expect(mockConsoleSDKInstance.getCredentials).toHaveBeenCalledWith(
+        dataMocks.org.id,
+        dataMocks.project.id,
+        dataMocks.workspace.id
+      )
+      expect(mockConsoleSDKInstance.getFirstOAuthServerToServerCredentials).not.toHaveBeenCalled()
+    })
+    test('returns undefined when no credentials are available', async () => {
+      mockConsoleSDKInstance.getCredentials.mockResolvedValue({ body: [] })
+      const ret = await consoleCli.getWorkspaceCreds(
         dataMocks.org.id,
         dataMocks.project.id,
         dataMocks.workspace


### PR DESCRIPTION
The proposed changes will allow for the successful retrieval of either OAuth or JWT credentials through composition, so that App Builder template developers don't have the need to hardcode in the template which credential to retrieve.

## Description

The new changes add conditional logic to look for OAuth credentials, and if such credentials are undefined, it will look for the JWT ones. This change will also make room for future auth providers to be added into the conditional.

## Related Issue

https://github.com/adobe/commerce-events-ext-tpl/pull/6

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This update will benefit App Builder template developers by removing the requirement to hard code credentials in each template, whether existing or new. This change significantly reduces the need for hardcoded information in templates that support multiple authentication protocols, as well as the possibility of new auth providers to be added in the future. 

## How Has This Been Tested?

These changes were tested specifically with `_commerce-events-ext-tpl_` commerce template for App Builder. With the proposed additional code, apps were successfully initialized and deployed for projects using both JWT and OAuth credentials, including half-way the migration process from JWT to OAuth.


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
