### PR TITLE
fix: ACNA-2523 - change subscribeToServicesWithCredentialType to use existing (OAuth S2S OR JWT), if either does not exist, then create

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -343,14 +343,7 @@ class LibConsoleCLI {
   }) {
     // prepare the service info payload, with License Configs "Add" payload for each services
     const serviceInfo = helpers.servicePropertiesToServiceSubscriptionPayload(serviceProperties)
-
-    // get or create credentials
-    let credential
-    if (credentialType === LibConsoleCLI.OAUTH_SERVER_TO_SERVER_CREDENTIAL) {
-      credential = await this.getFirstOAuthServerToServerCredentials(orgId, project.id, workspace)
-    } else { // default is jwt
-      credential = await this.getFirstEntpCredentials(orgId, project.id, workspace)
-    }
+    const credential = await this.getFirstWorkspaceCredential(orgId, project.id, workspace)
 
     let credentialId = credential && credential.id_integration
     if (!credentialId) {


### PR DESCRIPTION
closes #73

## How Has This Been Tested?

- npm test
- manual test
  - `aio app init --standalone app my-app` (Create a new app)
  - `aio app add service` (add an action, say User Management API)
  - `aio app add service --use-jwt` (add an action, say Analytics)
  - check that the project does not have any duplicate enterprise credentials (no JWT) in Developer Console

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
