### PR TITLE
fix: scopes not attached to credentials when adding services

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -357,7 +357,10 @@ class LibConsoleCLI {
         )).id
       } else { // default is jwt
         credentialId = (await this.createEnterpriseCredentials(orgId, project, workspace, certDir)).id
+        credentialType = 'entp'
       }
+    } else { // If using an existing credential, ignore the passed credential type. If it's a service credential, use 'entp'...
+      credentialType = credential.integration_type === 'service' ? 'entp' : credential.integration_type
     }
 
     spinner.start(`Attaching Services to the ${credentialType} Credentials of Workspace ${workspace.name}...`)
@@ -368,7 +371,7 @@ class LibConsoleCLI {
       orgId,
       project.id,
       workspace.id,
-      'entp',
+      credentialType,
       credentialId,
       serviceInfo
     )).body
@@ -768,7 +771,7 @@ class LibConsoleCLI {
 }
 
 LibConsoleCLI.JWT_CREDENTIAL = 'jwt'
-LibConsoleCLI.OAUTH_SERVER_TO_SERVER_CREDENTIAL = 'oauth server-to-server'
+LibConsoleCLI.OAUTH_SERVER_TO_SERVER_CREDENTIAL = 'oauth_server_to_server'
 
 // static function making sure there are no spinner running (e.g. in case of error)
 LibConsoleCLI.cleanStdOut = () => { spinner.stop() }

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -372,7 +372,7 @@ describe('instance methods tests', () => {
           orgId,
           projectId,
           workspaceId,
-          integrations[0].flow_type,
+          integrations[0].integration_type,
           integrations[0].id_integration,
           dataMocks.subscribeServicesPayload
         )
@@ -399,7 +399,7 @@ describe('instance methods tests', () => {
           orgId,
           projectId,
           workspaceId,
-          integrations[0].flow_type,
+          integrations[0].integration_type,
           integrations[0].id_integration,
           dataMocks.subscribeServicesPayload
         )
@@ -569,7 +569,7 @@ describe('instance methods tests', () => {
           orgId,
           projectId,
           workspaceId,
-          oauthS2SCredential.flow_type,
+          oauthS2SCredential.integration_type,
           oauthS2SCredential.id_integration,
           dataMocks.subscribeServicesPayload
         )


### PR DESCRIPTION
Fixes https://github.com/adobe/aio-cli/issues/697

We were always using credential type of 'entp' when subscribing to services, but it has to be 'oauth_server_to_server' for oauth credentials 

I believe the extra code for handling an existing credential is for the case where the user's local config is out of date with the server, but truthfully didn't fully test this, just needed it to make sure the tests passed