### PR TITLE
fix: update @adobe/aio-lib-console to v5.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@adobe/aio-cli-plugin-certificate": "^2",
-    "@adobe/aio-lib-console": "^5",
+    "@adobe/aio-lib-console": "^5.4.2",
     "@adobe/aio-lib-core-logging": "^3",
     "fs-extra": "^11",
     "fuzzy": "^0.1.3",


### PR DESCRIPTION
## Motivation and Context

Explicitly add it for a new feature in 5.4.0 https://github.com/adobe/aio-lib-console/releases
This is so I can use the underlying @adobe/aio-lib-console of this lib in the app plugin, without having to add yet another dependency.

I need to use this new feature in @adobe/aio-lib-console for the audit log api, for the non-logged in use cases

```
const LibConsoleCLI = require('@adobe/aio-cli-lib-console')
const consoleCLI = await LibConsoleCLI.init({ accessToken, env, apiKey: CONSOLE_API_KEYS[env] })
// to get the underlying @adobe/aio-lib-console, you do
const libConsole = consoleCLI.sdkClient
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
