### PR TITLE
fix: lazy-load ora spinner to prevent MaxListenersExceededWarning

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ Console API calls, Std I/O (including prompts), File I/O and pure helpers */
 const fs = require('fs-extra')
 const consoleSdk = require('@adobe/aio-lib-console')
 const certPlugin = require('@adobe/aio-cli-plugin-certificate')
-const spinner = require('ora')()
+const ora = require('ora')
 const loggerNamespace = '@adobe/aio-cli-lib-console'
 const logger = require('@adobe/aio-lib-core-logging')(
   loggerNamespace,
@@ -24,6 +24,15 @@ const logger = require('@adobe/aio-lib-core-logging')(
 const promptBuilder = require('./prompt')
 const validators = require('./validate')
 const helpers = require('./pure-helpers')
+
+let _spinner
+/** @private */
+const getSpinner = () => {
+  if (!_spinner) {
+    _spinner = ora()
+  }
+  return _spinner
+}
 
 // consts
 const PROJECT_TYPE = 'jaeger'
@@ -66,9 +75,9 @@ class LibConsoleCLI {
   }
 
   async getOrganizations () {
-    spinner.start('Getting Organizations...')
+    getSpinner().start('Getting Organizations...')
     const organizations = (await this.sdkClient.getOrganizations()).body
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Get Organizations response: ${JSON.stringify(organizations, null, 2)}`)
     return organizations
   }
@@ -89,9 +98,9 @@ class LibConsoleCLI {
   }
 
   async getProjects (orgId) {
-    spinner.start('Getting Projects...')
+    getSpinner().start('Getting Projects...')
     const projects = (await this.sdkClient.getProjectsForOrg(orgId)).body
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Get Projects response for Org ${orgId}: ${JSON.stringify(projects, null, 2)}`)
     return projects
   }
@@ -104,9 +113,9 @@ class LibConsoleCLI {
    * @returns {object} Project metadata
    */
   async getProject (orgId, projectId) {
-    spinner.start('Getting Project...')
+    getSpinner().start('Getting Project...')
     const project = (await this.sdkClient.getProject(orgId, projectId)).body
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Get Project response for Org ${orgId}: ${JSON.stringify(project, null, 2)}`)
     return project
   }
@@ -119,9 +128,9 @@ class LibConsoleCLI {
    * @returns {object} Extension point metadata
    */
   async getApplicationExtensions (orgId, appId) {
-    spinner.start('Getting Application Extensions...')
+    getSpinner().start('Getting Application Extensions...')
     const extensionPoints = (await this.sdkClient.getApplicationExtensions(orgId, appId)).body.data
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Get Application Extensions response for Org ${orgId}: ${JSON.stringify(extensionPoints, null, 2)}`)
     return extensionPoints
   }
@@ -142,9 +151,9 @@ class LibConsoleCLI {
   }
 
   async getWorkspaces (orgId, projectId) {
-    spinner.start('Getting Workspaces...')
+    getSpinner().start('Getting Workspaces...')
     const workspaces = (await this.sdkClient.getWorkspacesForProject(orgId, projectId)).body
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Get Workspaces response for Project ${projectId} in Org ${orgId}: ${JSON.stringify(workspaces, null, 2)}`)
     return workspaces
   }
@@ -188,7 +197,7 @@ class LibConsoleCLI {
     const { name, title, description } = createProjectDetails
 
     // create the project, get the projectId
-    spinner.start('Creating Project...')
+    getSpinner().start('Creating Project...')
     const createdProject = (await this.sdkClient.createProject(
       orgId,
       { name, title, description, type: PROJECT_TYPE }
@@ -196,19 +205,19 @@ class LibConsoleCLI {
     const projectId = createdProject.projectId
 
     // create the missing stage workspace
-    spinner.text = 'Creating Stage Workspace...'
+    getSpinner().text = 'Creating Stage Workspace...'
     await this.sdkClient.createWorkspace(orgId, projectId, { name: 'Stage' })
 
     // enable runtime on the Production and Stage workspace
-    spinner.text = 'Enabling Adobe I/O Runtime...'
+    getSpinner().text = 'Enabling Adobe I/O Runtime...'
     const workspaces = (await (this.sdkClient.getWorkspacesForProject(orgId, projectId))).body
     await Promise.all(workspaces.map(w => this.sdkClient.createRuntimeNamespace(orgId, projectId, w.id)))
 
     // get complete record
-    spinner.text = 'Getting new Project...'
+    getSpinner().text = 'Getting new Project...'
     const project = (await this.sdkClient.getProject(orgId, projectId)).body
 
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Created project: ${JSON.stringify(project, null, 2)}`)
     return project
   }
@@ -231,9 +240,9 @@ class LibConsoleCLI {
   async createWorkspace (orgId, projectId, createWorkspaceDetails) {
     const { name, title } = createWorkspaceDetails
 
-    spinner.start()
+    getSpinner().start()
     // create workspace, retrieve workspaceId
-    spinner.text = 'Creating Workspace...'
+    getSpinner().text = 'Creating Workspace...'
     const createdWorkspace = (await this.sdkClient.createWorkspace(
       orgId,
       projectId,
@@ -242,22 +251,22 @@ class LibConsoleCLI {
     const workspaceId = createdWorkspace.workspaceId
 
     // enable runtime on the newly created workspace
-    spinner.text = 'Enabling Adobe I/O Runtime...'
+    getSpinner().text = 'Enabling Adobe I/O Runtime...'
     await this.sdkClient.createRuntimeNamespace(orgId, projectId, workspaceId)
 
     // get complete record
-    spinner.text = 'Getting new Workspace...'
+    getSpinner().text = 'Getting new Workspace...'
     const workspace = (await this.sdkClient.getWorkspace(orgId, projectId, workspaceId)).body
 
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Created Workspace: ${JSON.stringify(workspace, null, 2)}`)
     return workspace
   }
 
   async checkDevTermsForOrg (orgId) {
-    spinner.start('Checking Developer Terms of Service status...')
+    getSpinner().start('Checking Developer Terms of Service status...')
     const res = await this.sdkClient.checkOrgDevTerms(orgId)
-    spinner.stop()
+    getSpinner().stop()
     const termsAccepted = res.body.current && res.body.accepted
     const termsAcceptedDebug = termsAccepted ? 'accepted' : 'not accepted'
     logger.debug(`Developer terms were ${termsAcceptedDebug} for ${orgId}`)
@@ -265,9 +274,9 @@ class LibConsoleCLI {
   }
 
   async getDevTermsForOrg () {
-    spinner.start('Fetching Developer Terms of Service...')
+    getSpinner().start('Fetching Developer Terms of Service...')
     const res = await this.sdkClient.getDevTerms()
-    spinner.stop()
+    getSpinner().stop()
     return helpers.getDevTerms(res.body)
   }
 
@@ -277,9 +286,9 @@ class LibConsoleCLI {
   }
 
   async getEnabledServicesForOrg (orgId) {
-    spinner.start('Retrieving services supported by the Organization...')
+    getSpinner().start('Retrieving services supported by the Organization...')
     const res = await this.sdkClient.getServicesForOrg(orgId)
-    spinner.stop()
+    getSpinner().stop()
     const enabledServices = helpers.filterEnabledServices(res.body)
     logger.debug(`Enabled Services in Org ${orgId}: ${JSON.stringify(enabledServices, null, 2)}`)
     return enabledServices
@@ -363,7 +372,7 @@ class LibConsoleCLI {
       credentialType = credential.integration_type === 'service' ? 'entp' : credential.integration_type
     }
 
-    spinner.start(`Attaching Services to the ${credentialType} Credentials of Workspace ${workspace.name}...`)
+    getSpinner().start(`Attaching Services to the ${credentialType} Credentials of Workspace ${workspace.name}...`)
 
     logger.debug(`Subscription Payload: ${JSON.stringify(serviceInfo, null, 2)}`)
 
@@ -376,7 +385,7 @@ class LibConsoleCLI {
       serviceInfo
     )).body
 
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Subscription Response: ${JSON.stringify(subscriptionResponse, null, 2)}`)
     // { sdkList: [<string>] }
     return subscriptionResponse
@@ -410,7 +419,7 @@ class LibConsoleCLI {
     if (!credential) {
       return []
     }
-    spinner.start(`Getting Services attached to the Workspace ${workspace.name}`)
+    getSpinner().start(`Getting Services attached to the Workspace ${workspace.name}`)
 
     const fromCredentialId = credential.id_integration
 
@@ -427,7 +436,7 @@ class LibConsoleCLI {
     const integrationResponse = await this.sdkClient.getIntegration(orgId, fromCredentialId)
     let serviceProperties = integrationResponse.body.serviceProperties
     if (serviceProperties.length <= 0) {
-      spinner.stop()
+      getSpinner().stop()
       return []
     }
 
@@ -439,7 +448,7 @@ class LibConsoleCLI {
       serviceProperties = helpers.fixServiceProperties(serviceProperties, supportedServices)
     }
 
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Service Properties for Workspace ${workspace.id}: ${JSON.stringify(serviceProperties, null, 2)}`)
     return serviceProperties
   }
@@ -467,15 +476,15 @@ class LibConsoleCLI {
     // Note: an alternative could be to use
     // generateKeyPairAndCreateEntpIntegrationForWorkspace from the graphQL Console API
 
-    spinner.start(`Generating Credential key pair for Workspace ${workspace.name}...`)
+    getSpinner().start(`Generating Credential key pair for Workspace ${workspace.name}...`)
     const { cert, privateKey } = certPlugin.generate(orgId + project.name + workspace.name, CERT_VALID_DAYS)
     fs.ensureDirSync(projectCertDir)
     fs.writeFileSync(publicKeyFilePath, cert)
     fs.writeFileSync(privateKeyFilePath, privateKey)
-    spinner.stop()
+    getSpinner().stop()
     console.error(`Key pair '${publicKeyFileName}, ${privateKeyFileName}' valid for '${CERT_VALID_DAYS}' days, has been created into the folder: ${projectCertDir}`)
 
-    spinner.start(`Creating Enterprise Credentials for Workspace ${workspace.name}...`)
+    getSpinner().start(`Creating Enterprise Credentials for Workspace ${workspace.name}...`)
     const createCredentialResponse = await this.sdkClient.createEnterpriseCredential(
       orgId,
       project.id,
@@ -487,14 +496,14 @@ class LibConsoleCLI {
       'Auto generated enterprise credentials from aio CLI'
     )
 
-    spinner.stop()
+    getSpinner().stop()
 
     logger.debug(`Create Credential Response: ${JSON.stringify(createCredentialResponse.body, null, 2)}`)
     return createCredentialResponse.body
   }
 
   async createOAuthServerToServerCredentials (orgId, project, workspace, name, description) {
-    spinner.start(`Creating OAuth Server-to-Server Credentials for Workspace ${workspace.name}...`)
+    getSpinner().start(`Creating OAuth Server-to-Server Credentials for Workspace ${workspace.name}...`)
     const createCredentialResponse = await this.sdkClient.createOAuthServerToServerCredential(
       orgId,
       project.id,
@@ -503,7 +512,7 @@ class LibConsoleCLI {
       description
     )
 
-    spinner.stop()
+    getSpinner().stop()
 
     logger.debug(`Create OAuth Server-to-Server Credential Response: ${JSON.stringify(createCredentialResponse.body, null, 2)}`)
     return createCredentialResponse.body
@@ -540,13 +549,13 @@ class LibConsoleCLI {
       logger.debug('The selected workspace does not have an Enterprise Credential.')
       return []
     }
-    spinner.start(`Get public key bindings for Enterprise Credentials in Workspace ${workspace.name}...`)
+    getSpinner().start(`Get public key bindings for Enterprise Credentials in Workspace ${workspace.name}...`)
     const getBindingsResponse = await this.sdkClient.getBindingsForIntegration(
       orgId,
       credentialId
     )
 
-    spinner.stop()
+    getSpinner().stop()
 
     logger.debug(`Get Bindings Response: ${JSON.stringify(getBindingsResponse.body, null, 2)}`)
     return getBindingsResponse.body
@@ -574,14 +583,14 @@ class LibConsoleCLI {
       logger.debug('The selected workspace does not have an Enterprise Credential.')
       return []
     }
-    spinner.start(`Uploading and binding certificate to Enterprise Credentials for Workspace ${workspace.name}...`)
+    getSpinner().start(`Uploading and binding certificate to Enterprise Credentials for Workspace ${workspace.name}...`)
     const uploadAndBindCertificateResponse = await this.sdkClient.uploadAndBindCertificate(
       orgId,
       credentialId,
       fs.createReadStream(publicKeyPath)
     )
 
-    spinner.stop()
+    getSpinner().stop()
 
     logger.debug(`Upload and Bind Certificate Response: ${JSON.stringify(uploadAndBindCertificateResponse.body, null, 2)}`)
     return uploadAndBindCertificateResponse.body
@@ -604,39 +613,39 @@ class LibConsoleCLI {
       logger.debug('The selected workspace does not have an Enterprise Credential.')
       return false
     }
-    spinner.start(`Deleting public key binding ${binding.certificateFingerprint} from Enterprise Credentials for Workspace ${workspace.name}...`)
+    getSpinner().start(`Deleting public key binding ${binding.certificateFingerprint} from Enterprise Credentials for Workspace ${workspace.name}...`)
     const deleteBindingResponse = await this.sdkClient.deleteBinding(
       orgId,
       credentialId,
       binding.bindingId
     )
 
-    spinner.stop()
+    getSpinner().stop()
 
     logger.debug(`Delete binding Response: ${deleteBindingResponse.status}`)
     return deleteBindingResponse.status === 200
   }
 
   async getFirstEntpCredentials (orgId, projectId, workspace) {
-    spinner.start(`Getting Enterprise Credentials attached to Workspace ${workspace.name}...`)
+    getSpinner().start(`Getting Enterprise Credentials attached to Workspace ${workspace.name}...`)
     const credentials = (await this.sdkClient.getCredentials(orgId, projectId, workspace.id)).body
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Get Credentials Response: ${JSON.stringify(credentials, null, 2)}`)
     return helpers.findFirstEntpCredential(credentials)
   }
 
   async getFirstOAuthServerToServerCredentials (orgId, projectId, workspace) {
-    spinner.start(`Getting OAuth Server-to-Server Credentials attached to Workspace ${workspace.name}...`)
+    getSpinner().start(`Getting OAuth Server-to-Server Credentials attached to Workspace ${workspace.name}...`)
     const credentials = (await this.sdkClient.getCredentials(orgId, projectId, workspace.id)).body
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Get Credentials Response: ${JSON.stringify(credentials, null, 2)}`)
     return helpers.findFirstOAuthServerToServerCredential(credentials)
   }
 
   async getFirstWorkspaceCredential (orgId, projectId, workspace) {
-    spinner.start(`Getting Credentials for Workspace ${workspace.name}...`)
+    getSpinner().start(`Getting Credentials for Workspace ${workspace.name}...`)
     const credentials = (await this.sdkClient.getCredentials(orgId, projectId, workspace.id)).body
-    spinner.stop()
+    getSpinner().stop()
     const oauthCreds = helpers.findFirstOAuthServerToServerCredential(credentials)
     if (oauthCreds !== undefined) {
       logger.debug(`OAuth Server-to-Server Credentials found: ${JSON.stringify(oauthCreds, null, 2)}`)
@@ -651,9 +660,9 @@ class LibConsoleCLI {
   }
 
   async getWorkspaceConfig (orgId, projectId, workspaceId, supportedServices = null) {
-    spinner.start('Downloading Workspace config...')
+    getSpinner().start('Downloading Workspace config...')
     let json = (await this.sdkClient.downloadWorkspaceJson(orgId, projectId, workspaceId)).body
-    spinner.stop()
+    getSpinner().stop()
     if (supportedServices !== null) {
       json = helpers.enhanceWorkspaceConfiguration(json, supportedServices)
     }
@@ -711,21 +720,21 @@ class LibConsoleCLI {
   }
 
   async getExtensionPoints (org, project, workspace) {
-    spinner.start(`Getting Extension Points in Workspace=${workspace.name}...`)
+    getSpinner().start(`Getting Extension Points in Workspace=${workspace.name}...`)
     // api returns null if not set
     logger.debug(`Get Extension Points for org: '${org.name}', project: '${project.name}', workspace: '${workspace.name}'`)
     const extensionPoints = (await this.sdkClient.getEndPointsInWorkspace(org.id, project.id, workspace.id)).body || {}
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Get Extension Points Response: ${JSON.stringify(extensionPoints, null, 2)}`)
     return { endpoints: extensionPoints }
   }
 
   async updateExtensionPoints (org, project, workspace, extensionPoints) {
-    spinner.start(`Updating Extension Points '${Object.keys(extensionPoints)}' in Workspace=${workspace.name}...`)
+    getSpinner().start(`Updating Extension Points '${Object.keys(extensionPoints)}' in Workspace=${workspace.name}...`)
     logger.debug(`Update Extension Points for org: '${org.name}', project: '${project.name}', workspace: '${workspace.name}'`)
     logger.debug(`Update Extension Points payload: ${JSON.stringify(extensionPoints, null, 2)}`)
     const res = (await this.sdkClient.updateEndPointsInWorkspace(org.id, project.id, workspace.id, extensionPoints)).body || {}
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Update Extension Points response: ${JSON.stringify(res, null, 2)}`)
     return { endpoints: res }
   }
@@ -762,9 +771,9 @@ class LibConsoleCLI {
    * @returns {Array} extension-point list
    */
   async getAllExtensionPoints (orgId, xpId) {
-    spinner.start(`Getting All Extension Points for Org=${orgId}...`)
+    getSpinner().start(`Getting All Extension Points for Org=${orgId}...`)
     const extensionPoints = (await this.sdkClient.getAllExtensionPoints(orgId, xpId)).body || {}
-    spinner.stop()
+    getSpinner().stop()
     logger.debug(`Get All Extension Points Response: ${JSON.stringify(extensionPoints, null, 2)}`)
     return extensionPoints
   }
@@ -774,5 +783,5 @@ LibConsoleCLI.JWT_CREDENTIAL = 'jwt'
 LibConsoleCLI.OAUTH_SERVER_TO_SERVER_CREDENTIAL = 'oauth_server_to_server'
 
 // static function making sure there are no spinner running (e.g. in case of error)
-LibConsoleCLI.cleanStdOut = () => { spinner.stop() }
+LibConsoleCLI.cleanStdOut = () => { getSpinner().stop() }
 module.exports = LibConsoleCLI


### PR DESCRIPTION
## Summary

Fixes #99

- `ora()` was called at module load time (`const spinner = require('ora')()`), causing ora's internal `StdinDiscarder` to pipe to `process.stdout` and register an `error` event listener immediately on require
- Each time the module was freshly loaded, a new listener was added, eventually triggering `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [WriteStream]`
- Replaced the module-level singleton with a lazy `getSpinner()` getter that creates the ora instance only on first use

## Test plan

- [x] All 172 existing tests pass with 100% coverage
- [x] `cleanStdOut` static method continues to work correctly via `getSpinner()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)